### PR TITLE
sf: Fix blending mode for legacy BSP

### DIFF
--- a/services/surfaceflinger/Layer.cpp
+++ b/services/surfaceflinger/Layer.cpp
@@ -467,7 +467,7 @@ void Layer::setGeometry(
 
     // this gives us only the "orientation" component of the transform
     const State& s(getDrawingState());
-#ifdef QTI_BSP
+#if defined(QCOM_BSP) && !defined(QCOM_BSP_LEGACY)
     if (!isOpaque(s)) {
 #else
     if (!isOpaque(s) || s.alpha != 0xFF) {


### PR DESCRIPTION
- After 0c5f3af, glitches when blending is observed on
  A family devices. Modify ifdef to not include QCOM_BSP_LEGACY.

Change-Id: Ibb53df5709abbb0e7132065aec23a14f7accf4b3
